### PR TITLE
Eliminate compile warnings

### DIFF
--- a/ext/rkerberos/config.c
+++ b/ext/rkerberos/config.c
@@ -163,10 +163,7 @@ static VALUE rkadm5_config_initialize(VALUE self){
 }
 
 static VALUE rkadm5_config_inspect(VALUE self){
-  RUBY_KADM5_CONFIG* ptr;
   VALUE v_str;
-
-  Data_Get_Struct(self, RUBY_KADM5_CONFIG, ptr); 
 
   v_str = rb_str_new2("#<");
   rb_str_buf_cat2(v_str, rb_obj_classname(self));

--- a/ext/rkerberos/extconf.rb
+++ b/ext/rkerberos/extconf.rb
@@ -21,5 +21,5 @@ else
   raise 'kdb5 library not found'
 end
 
-$CFLAGS << '-std=c99'
+$CFLAGS << '-std=c99 -Wall -pedantic'
 create_makefile('rkerberos')

--- a/ext/rkerberos/kadm5.c
+++ b/ext/rkerberos/kadm5.c
@@ -202,15 +202,17 @@ static VALUE rkadm5_initialize(VALUE self, VALUE v_opts){
  * Set the password for +user+ (i.e. the principal) to +password+.
  */
 static VALUE rkadm5_set_password(VALUE self, VALUE v_user, VALUE v_pass){
+  RUBY_KADM5* ptr;
+  krb5_error_code kerror;
+  char *user;
+  char *pass;
+
   Check_Type(v_user, T_STRING);
   Check_Type(v_pass, T_STRING);
 
-  RUBY_KADM5* ptr;
-  char* user = StringValuePtr(v_user);
-  char* pass = StringValuePtr(v_pass);
-  krb5_error_code kerror;
-
   Data_Get_Struct(self, RUBY_KADM5, ptr);
+  user = StringValuePtr(v_user);
+  pass = StringValuePtr(v_pass);
 
   if(!ptr->ctx)
     rb_raise(cKadm5Exception, "no context has been established");
@@ -248,10 +250,10 @@ static VALUE rkadm5_create_principal(int argc, VALUE* argv, VALUE self){
   int mask;
   kadm5_principal_ent_rec princ;
   krb5_error_code kerror;
+  VALUE v_user, v_pass, v_db_args;
 
   Data_Get_Struct(self, RUBY_KADM5, ptr);
 
-  VALUE v_user, v_pass, v_db_args;
   rb_scan_args(argc, argv, "21", &v_user, &v_pass, &v_db_args);
   Check_Type(v_user, T_STRING);
   Check_Type(v_pass, T_STRING);
@@ -978,8 +980,7 @@ char** parse_db_args(VALUE v_db_args){
       // Multiple arguments
       array_length = RARRAY_LEN(v_db_args);
       db_args = (char **) malloc(array_length * sizeof(char *) + 1);
-      long i;
-      for(i = 0; i < array_length; ++i){
+      for(long i = 0; i < array_length; ++i){
         VALUE elem = rb_ary_entry(v_db_args, i);
         Check_Type(elem, T_STRING);
         db_args[i] = StringValueCStr(elem);

--- a/ext/rkerberos/kadm5.c
+++ b/ext/rkerberos/kadm5.c
@@ -91,7 +91,7 @@ static VALUE rkadm5_initialize(VALUE self, VALUE v_opts){
   v_service = rb_hash_aref2(v_opts, "service");
 
   if(NIL_P(v_service)){
-    service = "kadmin/admin";
+    service = (char *) "kadmin/admin";
   }
   else{
     Check_Type(v_service, T_STRING);

--- a/ext/rkerberos/kadm5.c
+++ b/ext/rkerberos/kadm5.c
@@ -877,7 +877,7 @@ static VALUE rkadm5_get_privs(int argc, VALUE* argv, VALUE self){
   VALUE v_return = Qnil;
   VALUE v_strings = Qfalse;
   kadm5_ret_t kerror;
-  int i;
+  unsigned int i;
   long privs;
   int result = 0;
 

--- a/ext/rkerberos/keytab_entry.c
+++ b/ext/rkerberos/keytab_entry.c
@@ -27,8 +27,6 @@ static VALUE rkrb5_kt_entry_allocate(VALUE klass){
  * methods.
  */
 static VALUE rkrb5_kt_entry_initialize(VALUE self){
-  RUBY_KRB5_KT_ENTRY* ptr;
-  Data_Get_Struct(self, RUBY_KRB5_KT_ENTRY, ptr); 
   return self;
 }
 
@@ -36,10 +34,8 @@ static VALUE rkrb5_kt_entry_initialize(VALUE self){
  * A custom inspect method for nicer output.
  */
 static VALUE rkrb5_kt_entry_inspect(VALUE self){
-  RUBY_KRB5_KT_ENTRY* ptr;
   VALUE v_str;
 
-  Data_Get_Struct(self, RUBY_KRB5_KT_ENTRY, ptr);
   v_str = rb_str_new2("#<"); 
   rb_str_buf_cat2(v_str, rb_obj_classname(self));
   rb_str_buf_cat2(v_str, " ");

--- a/ext/rkerberos/keytab_entry.c
+++ b/ext/rkerberos/keytab_entry.c
@@ -37,9 +37,9 @@ static VALUE rkrb5_kt_entry_initialize(VALUE self){
  */
 static VALUE rkrb5_kt_entry_inspect(VALUE self){
   RUBY_KRB5_KT_ENTRY* ptr;
-  Data_Get_Struct(self, RUBY_KRB5_KT_ENTRY, ptr);
   VALUE v_str;
 
+  Data_Get_Struct(self, RUBY_KRB5_KT_ENTRY, ptr);
   v_str = rb_str_new2("#<"); 
   rb_str_buf_cat2(v_str, rb_obj_classname(self));
   rb_str_buf_cat2(v_str, " ");

--- a/ext/rkerberos/policy.c
+++ b/ext/rkerberos/policy.c
@@ -117,10 +117,7 @@ static VALUE rkadm5_policy_init(VALUE self, VALUE v_options){
  * A custom inspect method for Policy objects.
  */
 static VALUE rkadm5_policy_inspect(VALUE self){
-  RUBY_KADM5_POLICY* ptr;
   VALUE v_str;
-
-  Data_Get_Struct(self, RUBY_KADM5_POLICY, ptr);
 
   v_str = rb_str_new2("#<");
   rb_str_buf_cat2(v_str, rb_obj_classname(self));

--- a/ext/rkerberos/principal.c
+++ b/ext/rkerberos/principal.c
@@ -146,10 +146,7 @@ static VALUE rkrb5_princ_equal(VALUE self, VALUE v_other){
  * A custom inspect method for the Principal object.
  */
 static VALUE rkrb5_princ_inspect(VALUE self){
-  RUBY_KRB5_PRINC* ptr;
   VALUE v_str;
-
-  Data_Get_Struct(self, RUBY_KRB5_PRINC, ptr); 
 
   v_str = rb_str_new2("#<");
   rb_str_buf_cat2(v_str, rb_obj_classname(self));

--- a/ext/rkerberos/rkerberos.c
+++ b/ext/rkerberos/rkerberos.c
@@ -270,17 +270,21 @@ static VALUE rkrb5_get_init_creds_keytab(int argc, VALUE* argv, VALUE self){
  * krb5.change_password('XXXXXX', 'YYYYYY')      # Change password for 'foo'
  */
 static VALUE rkrb5_change_password(VALUE self, VALUE v_old, VALUE v_new){
-  Check_Type(v_old, T_STRING);
-  Check_Type(v_new, T_STRING);
 
   RUBY_KRB5* ptr;
   krb5_data result_string;
   krb5_data pw_result_string;
   krb5_error_code kerror;
+  char *old_passwd;
+  char *new_passwd;
 
   int pw_result;
-  char* old_passwd = StringValuePtr(v_old);
-  char* new_passwd = StringValuePtr(v_new);
+
+  Check_Type(v_old, T_STRING);
+  Check_Type(v_new, T_STRING);
+
+  old_passwd = StringValuePtr(v_old);
+  new_passwd = StringValuePtr(v_new);
 
   Data_Get_Struct(self, RUBY_KRB5, ptr); 
 

--- a/ext/rkerberos/rkerberos.c
+++ b/ext/rkerberos/rkerberos.c
@@ -7,7 +7,7 @@ VALUE cKrb5Exception;
 // Function prototypes
 static VALUE rkrb5_close(VALUE);
 
-VALUE rb_hash_aref2(VALUE v_hash, char* key){
+VALUE rb_hash_aref2(VALUE v_hash, const char* key){
   VALUE v_key, v_val;
 
   v_key = rb_str_new2(key);

--- a/ext/rkerberos/rkerberos.h
+++ b/ext/rkerberos/rkerberos.h
@@ -20,7 +20,7 @@ void Init_keytab_entry();
 void Init_ccache();
 
 // Defined in rkerberos.c
-VALUE rb_hash_aref2(VALUE, char*);
+VALUE rb_hash_aref2(VALUE, const char*);
 
 // Variable declarations
 extern VALUE mKerberos;


### PR DESCRIPTION
These are not behavioural changes, only cosmetic changes to eliminate compile-time warnings.

I'm doing these things as PRs rather than committing directly in hopes of somebody eyeballing my changes. If you don't have the time to do this at this point, I'll switch to simply committing my changes directly after testing.

Fixes #15 