### PR TITLE
Fix principal segfault

### DIFF
--- a/ext/rkerberos/ccache.c
+++ b/ext/rkerberos/ccache.c
@@ -56,7 +56,7 @@ static VALUE rkrb5_ccache_initialize(int argc, VALUE* argv, VALUE self){
 
     kerror = krb5_parse_name(
       ptr->ctx,
-      StringValuePtr(v_principal),
+      StringValueCStr(v_principal),
       &ptr->principal
     );
 
@@ -79,7 +79,7 @@ static VALUE rkrb5_ccache_initialize(int argc, VALUE* argv, VALUE self){
   }
   else{
     Check_Type(v_name, T_STRING);
-    kerror = krb5_cc_resolve(ptr->ctx, StringValuePtr(v_name), &ptr->ccache);
+    kerror = krb5_cc_resolve(ptr->ctx, StringValueCStr(v_name), &ptr->ccache);
 
     if(kerror)
       rb_raise(cKrb5Exception, "krb5_cc_resolve: %s", error_message(kerror));

--- a/ext/rkerberos/config.c
+++ b/ext/rkerberos/config.c
@@ -163,10 +163,7 @@ static VALUE rkadm5_config_initialize(VALUE self){
 }
 
 static VALUE rkadm5_config_inspect(VALUE self){
-  RUBY_KADM5_CONFIG* ptr;
   VALUE v_str;
-
-  Data_Get_Struct(self, RUBY_KADM5_CONFIG, ptr); 
 
   v_str = rb_str_new2("#<");
   rb_str_buf_cat2(v_str, rb_obj_classname(self));

--- a/ext/rkerberos/extconf.rb
+++ b/ext/rkerberos/extconf.rb
@@ -21,5 +21,5 @@ else
   raise 'kdb5 library not found'
 end
 
-$CFLAGS << '-std=c99'
+$CFLAGS << '-std=c99 -Wall -pedantic'
 create_makefile('rkerberos')

--- a/ext/rkerberos/kadm5.c
+++ b/ext/rkerberos/kadm5.c
@@ -202,15 +202,17 @@ static VALUE rkadm5_initialize(VALUE self, VALUE v_opts){
  * Set the password for +user+ (i.e. the principal) to +password+.
  */
 static VALUE rkadm5_set_password(VALUE self, VALUE v_user, VALUE v_pass){
+  RUBY_KADM5* ptr;
+  krb5_error_code kerror;
+  char *user;
+  char *pass;
+
   Check_Type(v_user, T_STRING);
   Check_Type(v_pass, T_STRING);
 
-  RUBY_KADM5* ptr;
-  char* user = StringValuePtr(v_user);
-  char* pass = StringValuePtr(v_pass);
-  krb5_error_code kerror;
-
   Data_Get_Struct(self, RUBY_KADM5, ptr);
+  user = StringValuePtr(v_user);
+  pass = StringValuePtr(v_pass);
 
   if(!ptr->ctx)
     rb_raise(cKadm5Exception, "no context has been established");
@@ -248,10 +250,10 @@ static VALUE rkadm5_create_principal(int argc, VALUE* argv, VALUE self){
   int mask;
   kadm5_principal_ent_rec princ;
   krb5_error_code kerror;
+  VALUE v_user, v_pass, v_db_args;
 
   Data_Get_Struct(self, RUBY_KADM5, ptr);
 
-  VALUE v_user, v_pass, v_db_args;
   rb_scan_args(argc, argv, "21", &v_user, &v_pass, &v_db_args);
   Check_Type(v_user, T_STRING);
   Check_Type(v_pass, T_STRING);
@@ -978,8 +980,7 @@ char** parse_db_args(VALUE v_db_args){
       // Multiple arguments
       array_length = RARRAY_LEN(v_db_args);
       db_args = (char **) malloc(array_length * sizeof(char *) + 1);
-      long i;
-      for(i = 0; i < array_length; ++i){
+      for(long i = 0; i < array_length; ++i){
         VALUE elem = rb_ary_entry(v_db_args, i);
         Check_Type(elem, T_STRING);
         db_args[i] = StringValueCStr(elem);

--- a/ext/rkerberos/kadm5.c
+++ b/ext/rkerberos/kadm5.c
@@ -75,7 +75,7 @@ static VALUE rkadm5_initialize(VALUE self, VALUE v_opts){
     rb_raise(rb_eArgError, "principal must be specified");
 
   Check_Type(v_principal, T_STRING);
-  user = StringValuePtr(v_principal);
+  user = StringValueCStr(v_principal);
 
   v_password = rb_hash_aref2(v_opts, "password");
   v_keytab = rb_hash_aref2(v_opts, "keytab");
@@ -85,7 +85,7 @@ static VALUE rkadm5_initialize(VALUE self, VALUE v_opts){
 
   if(RTEST(v_password)){
     Check_Type(v_password, T_STRING);
-    pass = StringValuePtr(v_password);
+    pass = StringValueCStr(v_password);
   }
 
   v_service = rb_hash_aref2(v_opts, "service");
@@ -95,7 +95,7 @@ static VALUE rkadm5_initialize(VALUE self, VALUE v_opts){
   }
   else{
     Check_Type(v_service, T_STRING);
-    service = StringValuePtr(v_service);
+    service = StringValueCStr(v_service);
   }
 
   v_db_args = rb_hash_aref2(v_opts, "db_args");
@@ -122,7 +122,7 @@ static VALUE rkadm5_initialize(VALUE self, VALUE v_opts){
     }
     else{
       Check_Type(v_keytab, T_STRING);
-      keytab = StringValuePtr(v_keytab);
+      keytab = StringValueCStr(v_keytab);
     }
   }
 
@@ -211,8 +211,8 @@ static VALUE rkadm5_set_password(VALUE self, VALUE v_user, VALUE v_pass){
   Check_Type(v_pass, T_STRING);
 
   Data_Get_Struct(self, RUBY_KADM5, ptr);
-  user = StringValuePtr(v_user);
-  pass = StringValuePtr(v_pass);
+  user = StringValueCStr(v_user);
+  pass = StringValueCStr(v_pass);
 
   if(!ptr->ctx)
     rb_raise(cKadm5Exception, "no context has been established");
@@ -261,8 +261,8 @@ static VALUE rkadm5_create_principal(int argc, VALUE* argv, VALUE self){
   memset(&princ, 0, sizeof(princ));
 
   mask = KADM5_PRINCIPAL | KADM5_TL_DATA;
-  user = StringValuePtr(v_user);
-  pass = StringValuePtr(v_pass);
+  user = StringValueCStr(v_user);
+  pass = StringValueCStr(v_pass);
 
   db_args = parse_db_args(v_db_args);
   add_db_args(&princ, db_args);
@@ -298,7 +298,7 @@ static VALUE rkadm5_delete_principal(VALUE self, VALUE v_user){
 
   Data_Get_Struct(self, RUBY_KADM5, ptr);
   Check_Type(v_user, T_STRING);
-  user = StringValuePtr(v_user);
+  user = StringValueCStr(v_user);
 
   if(!ptr->ctx)
     rb_raise(cKadm5Exception, "no context has been established");
@@ -423,7 +423,7 @@ static VALUE rkadm5_find_principal(VALUE self, VALUE v_user){
 
   Data_Get_Struct(self, RUBY_KADM5, ptr);
   Check_Type(v_user, T_STRING);
-  user = StringValuePtr(v_user);
+  user = StringValueCStr(v_user);
 
   memset(&ent, 0, sizeof(ent));
 
@@ -479,7 +479,7 @@ static VALUE rkadm5_get_principal(VALUE self, VALUE v_user){
 
   Data_Get_Struct(self, RUBY_KADM5, ptr);
   Check_Type(v_user, T_STRING);
-  user = StringValuePtr(v_user);
+  user = StringValueCStr(v_user);
 
   memset(&ent, 0, sizeof(ent));
 
@@ -550,7 +550,7 @@ static VALUE rkadm5_create_policy(VALUE self, VALUE v_policy){
   v_max_life    = rb_iv_get(v_policy, "@max_life");
   v_history_num = rb_iv_get(v_policy, "@history_num");
 
-  ent.policy = StringValuePtr(v_name);
+  ent.policy = StringValueCStr(v_name);
 
   if(RTEST(v_min_classes)){
     mask |= KADM5_PW_MIN_CLASSES;
@@ -602,7 +602,7 @@ static VALUE rkadm5_delete_policy(VALUE self, VALUE v_policy){
 
   Data_Get_Struct(self, RUBY_KADM5, ptr);
 
-  policy = StringValuePtr(v_policy);
+  policy = StringValueCStr(v_policy);
 
   kerror = kadm5_delete_policy(ptr->handle, policy);
 
@@ -635,7 +635,7 @@ static VALUE rkadm5_get_policy(VALUE self, VALUE v_name){
   if(!ptr->ctx)
     rb_raise(cKadm5Exception, "no context has been established");
 
-  policy_name = StringValuePtr(v_name);
+  policy_name = StringValueCStr(v_name);
 
   kerror = kadm5_get_policy(ptr->handle, policy_name, &ent); 
 
@@ -687,7 +687,7 @@ static VALUE rkadm5_find_policy(VALUE self, VALUE v_name){
   if(!ptr->ctx)
     rb_raise(cKadm5Exception, "no context has been established");
 
-  policy_name = StringValuePtr(v_name);
+  policy_name = StringValueCStr(v_name);
 
   kerror = kadm5_get_policy(ptr->handle, policy_name, &ent); 
 
@@ -791,7 +791,7 @@ static VALUE rkadm5_get_policies(int argc, VALUE* argv, VALUE self){
   if(NIL_P(v_expr))
     expr = NULL;
   else
-    expr = StringValuePtr(v_expr);
+    expr = StringValueCStr(v_expr);
 
   kerror = kadm5_get_policies(ptr->handle, expr, &pols, &count);
 
@@ -839,7 +839,7 @@ static VALUE rkadm5_get_principals(int argc, VALUE* argv, VALUE self){
   if(NIL_P(v_expr))
     expr = NULL;
   else
-    expr = StringValuePtr(v_expr);
+    expr = StringValueCStr(v_expr);
 
   kerror = kadm5_get_principals(ptr->handle, expr, &princs, &count);
 
@@ -940,7 +940,7 @@ static VALUE rkadm5_randkey_principal(VALUE self, VALUE v_user){
 
   Data_Get_Struct(self, RUBY_KADM5, ptr);
 
-  user = StringValuePtr(v_user);
+  user = StringValueCStr(v_user);
 
   if(!ptr->ctx)
     rb_raise(cKadm5Exception, "no context has been established");

--- a/ext/rkerberos/kadm5.c
+++ b/ext/rkerberos/kadm5.c
@@ -91,7 +91,7 @@ static VALUE rkadm5_initialize(VALUE self, VALUE v_opts){
   v_service = rb_hash_aref2(v_opts, "service");
 
   if(NIL_P(v_service)){
-    service = "kadmin/admin";
+    service = (char *) "kadmin/admin";
   }
   else{
     Check_Type(v_service, T_STRING);

--- a/ext/rkerberos/kadm5.c
+++ b/ext/rkerberos/kadm5.c
@@ -877,7 +877,7 @@ static VALUE rkadm5_get_privs(int argc, VALUE* argv, VALUE self){
   VALUE v_return = Qnil;
   VALUE v_strings = Qfalse;
   kadm5_ret_t kerror;
-  int i;
+  unsigned int i;
   long privs;
   int result = 0;
 

--- a/ext/rkerberos/keytab.c
+++ b/ext/rkerberos/keytab.c
@@ -143,7 +143,7 @@ static VALUE rkrb5_keytab_remove_entry(int argc, VALUE* argv, VALUE self){
 
   Check_Type(v_name, T_STRING);
 
-  name = StringValuePtr(v_name);
+  name = StringValueCStr(v_name);
 
   if(!ptr->ctx)
     rb_raise(cKrb5Exception, "no context has been established");
@@ -190,7 +190,7 @@ static VALUE rkrb5_keytab_add_entry(int argc, VALUE* argv, VALUE self){
 
   Check_Type(v_name, T_STRING);
 
-  name = StringValuePtr(v_name);
+  name = StringValueCStr(v_name);
 
   if(!ptr->ctx)
     rb_raise(cKrb5Exception, "no context has been established");
@@ -252,7 +252,7 @@ static VALUE rkrb5_keytab_get_entry(int argc, VALUE* argv, VALUE self){
   rb_scan_args(argc, argv, "12", &v_principal, &v_vno, &v_enctype);
 
   Check_Type(v_principal, T_STRING);
-  name = StringValuePtr(v_principal);
+  name = StringValueCStr(v_principal);
 
   kerror = krb5_parse_name(ptr->ctx, name, &principal);
 
@@ -331,7 +331,7 @@ static VALUE rkrb5_keytab_initialize(int argc, VALUE* argv, VALUE self){
   } 
   else{
     Check_Type(v_keytab_name, T_STRING);
-    strncpy(keytab_name, StringValuePtr(v_keytab_name), MAX_KEYTAB_NAME_LEN);
+    strncpy(keytab_name, StringValueCStr(v_keytab_name), MAX_KEYTAB_NAME_LEN);
     rb_iv_set(self, "@name", v_keytab_name);
   }
 
@@ -391,7 +391,7 @@ static VALUE rkrb5_s_keytab_foreach(int argc, VALUE* argv, VALUE klass){
   } 
   else{
     Check_Type(v_keytab_name, T_STRING);
-    strncpy(keytab_name, StringValuePtr(v_keytab_name), MAX_KEYTAB_NAME_LEN);
+    strncpy(keytab_name, StringValueCStr(v_keytab_name), MAX_KEYTAB_NAME_LEN);
   }
 
   kerror = krb5_kt_resolve(

--- a/ext/rkerberos/keytab_entry.c
+++ b/ext/rkerberos/keytab_entry.c
@@ -27,8 +27,6 @@ static VALUE rkrb5_kt_entry_allocate(VALUE klass){
  * methods.
  */
 static VALUE rkrb5_kt_entry_initialize(VALUE self){
-  RUBY_KRB5_KT_ENTRY* ptr;
-  Data_Get_Struct(self, RUBY_KRB5_KT_ENTRY, ptr); 
   return self;
 }
 
@@ -36,10 +34,8 @@ static VALUE rkrb5_kt_entry_initialize(VALUE self){
  * A custom inspect method for nicer output.
  */
 static VALUE rkrb5_kt_entry_inspect(VALUE self){
-  RUBY_KRB5_KT_ENTRY* ptr;
   VALUE v_str;
 
-  Data_Get_Struct(self, RUBY_KRB5_KT_ENTRY, ptr);
   v_str = rb_str_new2("#<"); 
   rb_str_buf_cat2(v_str, rb_obj_classname(self));
   rb_str_buf_cat2(v_str, " ");

--- a/ext/rkerberos/keytab_entry.c
+++ b/ext/rkerberos/keytab_entry.c
@@ -37,9 +37,9 @@ static VALUE rkrb5_kt_entry_initialize(VALUE self){
  */
 static VALUE rkrb5_kt_entry_inspect(VALUE self){
   RUBY_KRB5_KT_ENTRY* ptr;
-  Data_Get_Struct(self, RUBY_KRB5_KT_ENTRY, ptr);
   VALUE v_str;
 
+  Data_Get_Struct(self, RUBY_KRB5_KT_ENTRY, ptr);
   v_str = rb_str_new2("#<"); 
   rb_str_buf_cat2(v_str, rb_obj_classname(self));
   rb_str_buf_cat2(v_str, " ");

--- a/ext/rkerberos/policy.c
+++ b/ext/rkerberos/policy.c
@@ -63,7 +63,7 @@ static VALUE rkadm5_policy_init(VALUE self, VALUE v_options){
     rb_raise(rb_eArgError, "name policy option is mandatory");
   }
   else{
-    ptr->policy.policy = StringValuePtr(v_name);
+    ptr->policy.policy = StringValueCStr(v_name);
     rb_iv_set(self, "@policy", v_name);
   }
 

--- a/ext/rkerberos/policy.c
+++ b/ext/rkerberos/policy.c
@@ -117,10 +117,7 @@ static VALUE rkadm5_policy_init(VALUE self, VALUE v_options){
  * A custom inspect method for Policy objects.
  */
 static VALUE rkadm5_policy_inspect(VALUE self){
-  RUBY_KADM5_POLICY* ptr;
   VALUE v_str;
-
-  Data_Get_Struct(self, RUBY_KADM5_POLICY, ptr);
 
   v_str = rb_str_new2("#<");
   rb_str_buf_cat2(v_str, rb_obj_classname(self));

--- a/ext/rkerberos/principal.c
+++ b/ext/rkerberos/principal.c
@@ -106,15 +106,12 @@ static VALUE rkrb5_princ_get_realm(VALUE self){
  */
 static VALUE rkrb5_princ_set_realm(VALUE self, VALUE v_realm){
   RUBY_KRB5_PRINC* ptr;
-  krb5_data kdata;
 
-  memset(&kdata, 0, sizeof(kdata));
   Data_Get_Struct(self, RUBY_KRB5_PRINC, ptr); 
 
   Check_Type(v_realm, T_STRING);
-  kdata.data = StringValueCStr(v_realm);
 
-  krb5_princ_set_realm(ptr->ctx, ptr->principal, &kdata);
+  krb5_set_principal_realm(ptr->ctx, ptr->principal, StringValueCStr(v_realm));
 
   return v_realm;
 }

--- a/ext/rkerberos/principal.c
+++ b/ext/rkerberos/principal.c
@@ -146,10 +146,7 @@ static VALUE rkrb5_princ_equal(VALUE self, VALUE v_other){
  * A custom inspect method for the Principal object.
  */
 static VALUE rkrb5_princ_inspect(VALUE self){
-  RUBY_KRB5_PRINC* ptr;
   VALUE v_str;
-
-  Data_Get_Struct(self, RUBY_KRB5_PRINC, ptr); 
 
   v_str = rb_str_new2("#<");
   rb_str_buf_cat2(v_str, rb_obj_classname(self));

--- a/ext/rkerberos/principal.c
+++ b/ext/rkerberos/principal.c
@@ -55,7 +55,7 @@ static VALUE rkrb5_princ_initialize(VALUE self, VALUE v_name){
   else{
     char* name;
     Check_Type(v_name, T_STRING);
-    name = StringValuePtr(v_name);
+    name = StringValueCStr(v_name);
     kerror = krb5_parse_name(ptr->ctx, name, &ptr->principal);
 
     if(kerror)
@@ -112,7 +112,7 @@ static VALUE rkrb5_princ_set_realm(VALUE self, VALUE v_realm){
   Data_Get_Struct(self, RUBY_KRB5_PRINC, ptr); 
 
   Check_Type(v_realm, T_STRING);
-  kdata.data = StringValuePtr(v_realm);
+  kdata.data = StringValueCStr(v_realm);
 
   krb5_princ_set_realm(ptr->ctx, ptr->principal, &kdata);
 

--- a/ext/rkerberos/rkerberos.c
+++ b/ext/rkerberos/rkerberos.c
@@ -270,17 +270,21 @@ static VALUE rkrb5_get_init_creds_keytab(int argc, VALUE* argv, VALUE self){
  * krb5.change_password('XXXXXX', 'YYYYYY')      # Change password for 'foo'
  */
 static VALUE rkrb5_change_password(VALUE self, VALUE v_old, VALUE v_new){
-  Check_Type(v_old, T_STRING);
-  Check_Type(v_new, T_STRING);
 
   RUBY_KRB5* ptr;
   krb5_data result_string;
   krb5_data pw_result_string;
   krb5_error_code kerror;
+  char *old_passwd;
+  char *new_passwd;
 
   int pw_result;
-  char* old_passwd = StringValuePtr(v_old);
-  char* new_passwd = StringValuePtr(v_new);
+
+  Check_Type(v_old, T_STRING);
+  Check_Type(v_new, T_STRING);
+
+  old_passwd = StringValuePtr(v_old);
+  new_passwd = StringValuePtr(v_new);
 
   Data_Get_Struct(self, RUBY_KRB5, ptr); 
 

--- a/ext/rkerberos/rkerberos.c
+++ b/ext/rkerberos/rkerberos.c
@@ -115,7 +115,7 @@ static VALUE rkrb5_set_default_realm(int argc, VALUE* argv, VALUE self){
   }
   else{
     Check_Type(v_realm, T_STRING);
-    realm = StringValuePtr(v_realm);
+    realm = StringValueCStr(v_realm);
   }
 
   kerror = krb5_set_default_realm(ptr->ctx, realm);
@@ -167,7 +167,7 @@ static VALUE rkrb5_get_init_creds_keytab(int argc, VALUE* argv, VALUE self){
   }
   else{
     Check_Type(v_service, T_STRING);
-    service = StringValuePtr(v_service);
+    service = StringValueCStr(v_service);
   }
 
   // Convert the name (or service name) to a kerberos principal.
@@ -187,7 +187,7 @@ static VALUE rkrb5_get_init_creds_keytab(int argc, VALUE* argv, VALUE self){
   }
   else{
     Check_Type(v_user, T_STRING);
-    user = StringValuePtr(v_user);
+    user = StringValueCStr(v_user);
 
     kerror = krb5_parse_name(ptr->ctx, user, &ptr->princ); 
 
@@ -208,7 +208,7 @@ static VALUE rkrb5_get_init_creds_keytab(int argc, VALUE* argv, VALUE self){
   }
   else{
     Check_Type(v_keytab_name, T_STRING);
-    strncpy(keytab_name, StringValuePtr(v_keytab_name), MAX_KEYTAB_NAME_LEN);
+    strncpy(keytab_name, StringValueCStr(v_keytab_name), MAX_KEYTAB_NAME_LEN);
   }
 
   kerror = krb5_kt_resolve(
@@ -283,8 +283,8 @@ static VALUE rkrb5_change_password(VALUE self, VALUE v_old, VALUE v_new){
   Check_Type(v_old, T_STRING);
   Check_Type(v_new, T_STRING);
 
-  old_passwd = StringValuePtr(v_old);
-  new_passwd = StringValuePtr(v_new);
+  old_passwd = StringValueCStr(v_old);
+  new_passwd = StringValueCStr(v_new);
 
   Data_Get_Struct(self, RUBY_KRB5, ptr); 
 
@@ -349,15 +349,15 @@ static VALUE rkrb5_get_init_creds_passwd(int argc, VALUE* argv, VALUE self){
 
   Check_Type(v_user, T_STRING);
   Check_Type(v_pass, T_STRING);
-  user = StringValuePtr(v_user);
-  pass = StringValuePtr(v_pass);
+  user = StringValueCStr(v_user);
+  pass = StringValueCStr(v_pass);
 
   if(NIL_P(v_service)){
     service = NULL;
   }
   else{
     Check_Type(v_service, T_STRING);
-    service = StringValuePtr(v_service);
+    service = StringValueCStr(v_service);
   }
 
   kerror = krb5_parse_name(ptr->ctx, user, &ptr->princ); 

--- a/ext/rkerberos/rkerberos.c
+++ b/ext/rkerberos/rkerberos.c
@@ -7,7 +7,7 @@ VALUE cKrb5Exception;
 // Function prototypes
 static VALUE rkrb5_close(VALUE);
 
-VALUE rb_hash_aref2(VALUE v_hash, char* key){
+VALUE rb_hash_aref2(VALUE v_hash, const char* key){
   VALUE v_key, v_val;
 
   v_key = rb_str_new2(key);

--- a/ext/rkerberos/rkerberos.h
+++ b/ext/rkerberos/rkerberos.h
@@ -20,7 +20,7 @@ void Init_keytab_entry();
 void Init_ccache();
 
 // Defined in rkerberos.c
-VALUE rb_hash_aref2(VALUE, char*);
+VALUE rb_hash_aref2(VALUE, const char*);
 
 // Variable declarations
 extern VALUE mKerberos;


### PR DESCRIPTION
The old way introduced a double-free error, since kerberos assumes that
it controls the memory that represents the realm, and as such, frees it
when krb5_free_principal is called. With krb5_set_principal_realm this
is avoided due to the realm string being copied into kerberos-controlled
memory.

(This PR is rebased on #17 and contains all changes that PR also contains)