### PR TITLE
Use pkg-config to discover krb5 flags & libs

### DIFF
--- a/ext/rkerberos/extconf.rb
+++ b/ext/rkerberos/extconf.rb
@@ -2,8 +2,9 @@ require 'mkmf'
 
 dir_config('rkerberos', '/usr/local')
 
-have_header('krb5.h')
-have_library('krb5')
+unless pkg_config('krb5')
+  raise 'krb5 library not found'
+end
 
 unless pkg_config('com_err')
   puts 'warning: com_err not found, usually a dependency for kadm5clnt'


### PR DESCRIPTION
The extfile generates a makefile that doesn't link the Kerberos crypto library on hosts where it's a dynamic library, which means the link can't succeed.
Now it instead asks pkg-config for cflags and libs, which solves that issue.

This should fix #5